### PR TITLE
feat: enable preset creation in preset select dropdown

### DIFF
--- a/src/components/closure-presets/ClosurePresetDropdown.tsx
+++ b/src/components/closure-presets/ClosurePresetDropdown.tsx
@@ -1,6 +1,11 @@
 import { useClosurePresetsListContext } from 'contexts';
 import { ClosurePreset } from 'interfaces/closure-preset';
 import { SelectHTMLAttributes, useMemo } from 'react';
+import {
+  ClosurePresetEditorManagerConsumer,
+  ClosurePresetEditorManagerProvider,
+} from './ClosurePresetEditorManager';
+import { useTranslation } from 'hooks';
 
 interface ClosurePresetDropdownProps {
   label: string;
@@ -14,6 +19,7 @@ interface ClosurePresetDropdownProps {
   >;
 }
 export function ClosurePresetDropdown(props: ClosurePresetDropdownProps) {
+  const { t } = useTranslation();
   const options = useOptionsWithInheritance(props.options);
   const optionsMap = useOptionsMap(options);
 
@@ -25,26 +31,50 @@ export function ClosurePresetDropdown(props: ClosurePresetDropdownProps) {
   };
 
   return (
-    <wz-select
-      {...props.selectProps}
-      label={props.label}
-      placeholder={props.placeholder}
-      ref={(select: HTMLSelectElement) => {
-        if (!select) return;
+    <ClosurePresetEditorManagerProvider>
+      <ClosurePresetEditorManagerConsumer>
+        {(presetEditor) => (
+          <wz-select
+            {...props.selectProps}
+            label={props.label}
+            placeholder={props.placeholder}
+            ref={(select: HTMLSelectElement) => {
+              if (!select) return;
 
-        select.addEventListener('change', handleChange);
+              select.addEventListener('change', handleChange);
 
-        return () => {
-          select.removeEventListener('change', handleChange);
-        };
-      }}
-    >
-      {Array.from(optionsMap.values()).map((option) => (
-        <wz-option key={option.id} value={option.id}>
-          {option.name}
-        </wz-option>
-      ))}
-    </wz-select>
+              return () => {
+                select.removeEventListener('change', handleChange);
+              };
+            }}
+          >
+            {Array.from(optionsMap.values()).map((option) => (
+              <wz-option key={option.id} value={option.id}>
+                {option.name}
+              </wz-option>
+            ))}
+
+            <wz-menu-divider />
+            <wz-menu-item
+              ref={(item: HTMLLIElement) => {
+                if (!item) return;
+
+                const handleClick = () => {
+                  presetEditor.openEditor();
+                };
+
+                item.addEventListener('click', handleClick);
+                return () => {
+                  item.removeEventListener('click', handleClick);
+                };
+              }}
+            >
+              {t('edit.closure.create_preset_dropdown_option')}
+            </wz-menu-item>
+          </wz-select>
+        )}
+      </ClosurePresetEditorManagerConsumer>
+    </ClosurePresetEditorManagerProvider>
   );
 }
 

--- a/src/components/closure-presets/ClosurePresetDropdown.tsx
+++ b/src/components/closure-presets/ClosurePresetDropdown.tsx
@@ -62,10 +62,18 @@ export function ClosurePresetDropdown(props: ClosurePresetDropdownProps) {
                 const handleClick = () => {
                   presetEditor.openEditor();
                 };
+                const handleKeyDown = (event: KeyboardEvent) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    handleClick();
+                  }
+                };
 
                 item.addEventListener('click', handleClick);
+                item.addEventListener('keydown', handleKeyDown);
                 return () => {
                   item.removeEventListener('click', handleClick);
+                  item.removeEventListener('keydown', handleKeyDown);
                 };
               }}
             >

--- a/src/components/closure-presets/ClosurePresetEditorManager.tsx
+++ b/src/components/closure-presets/ClosurePresetEditorManager.tsx
@@ -63,6 +63,9 @@ export function ClosurePresetEditorManagerProvider({
   );
 }
 
+export const ClosurePresetEditorManagerConsumer =
+  ClosurePresetEditorManagerContext.Consumer;
+
 export function useClosurePresetEditorManager() {
   const context = useContext(ClosurePresetEditorManagerContext);
   if (!context) {

--- a/src/localization/static/userscript.json
+++ b/src/localization/static/userscript.json
@@ -18,6 +18,7 @@
   "edit": {
     "closure": {
       "preset_apply_dropdown": "Select Closure Preset",
+      "create_preset_dropdown_option": "Create new",
       "recurrence": {
         "enable_checkbox": "Recurring Closure",
         "set_rules_btn": "Set Closure Repetition",


### PR DESCRIPTION
> [!TIP]
> Test the changes in this pull request by installing the [preview version](https://deployable-assets.editorx.dev/wme-closures-plus.dc1fc6f.user.js).

### Summary

This pull request adds the option to start the preset creation process from within the preset selection dropdown, increasing discoverability for this feature.

### Changes

To achieve the desired result, the `ClosurePresetEditorManager` had to be added above the select. To use the manager's value without creating sub-components, I exported the consumer as well and used it to render the dropdown. Added a `wz-menu-divider` below all the existing preset options, and a `wz-menu-item` with a `click` handler manually registered through `ref` (and cleaned up with `ref` cleanup function introduced in React 19) due to native event handler property failing. The `wz-menu-item` ensures the item won't be selected within the dropdown, but rather acts as a button.