### PR TITLE
fix: grant XHR access in the default meta.js file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wme-closures-plus",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wme-closures-plus",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-alpha.8",
         "@emotion/css": "^11.13.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "WME Closures+",
   "shortDisplayName": "Closures+",
   "author": "r0den",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.3",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/tampermonkey.dev-template.js
+++ b/tampermonkey.dev-template.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name WME Closures+ [DEV]
 // @description WME Closures+ extends the Waze Map Editor with advanced closure management features
-// @version 1.0.0-beta.1
+// @version 1.0.0-beta.3
 // @author r0den
 // @match https://*.waze.com/*editor*
 // @match https://waze.com/*editor*

--- a/tampermonkey.meta.js
+++ b/tampermonkey.meta.js
@@ -1,11 +1,12 @@
 // ==UserScript==
 // @name WME Closures+
 // @description WME Closures+ extends the Waze Map Editor with advanced closure management features
-// @version 1.0.0-beta.1
+// @version 1.0.0-beta.3
 // @author r0den
 // @match https://*.waze.com/*editor*
 // @match https://waze.com/*editor*
 // @match https://*.wazestg.com/*editor*
 // @connect distributions.crowdin.net
 // @require https://cdn.jsdelivr.net/gh/WazeSpace/wme-sdk-plus@v1/wme-sdk-plus.js
+// @grant GM_xmlhttpRequest
 // ==/UserScript==


### PR DESCRIPTION
This PR adds a tampermonkey directive to grant access to XHR. It has been added previously in the development header file but not in the public version of it.
The missing directive caused to script to fail loading because the XHR agent couldn't be found as shown in #52.

Fixes #52