### PR TITLE
feat: helper message in duration picker

### DIFF
--- a/src/components/DurationPicker.tsx
+++ b/src/components/DurationPicker.tsx
@@ -30,6 +30,7 @@ export function DurationPicker(props: DurationPickerProps) {
       onBlur={onBlur}
       onKeyDown={onKeyDown}
       errorMessage={error ? t('duration_picker.errors')[error] : null}
+      helperMessage={t('duration_picker.helper')}
       autocomplete="off"
     />
   );

--- a/src/localization/static/userscript.json
+++ b/src/localization/static/userscript.json
@@ -110,7 +110,8 @@
   "duration_picker": {
     "errors": {
       "INVALID_PATTERN": "* Invalid format"
-    }
+    },
+    "helper": "Use number+unit (m for minutes, h for hours, d for days, w for weeks). Combine, e.g., `1h 30m`."
   },
   "sidebar_tab": {
     "closure_presets": {

--- a/src/localization/utils/load-crowdin-strings.ts
+++ b/src/localization/utils/load-crowdin-strings.ts
@@ -7,7 +7,6 @@ export async function loadCrowdinStrings(
   fallbackStrings?: object,
   prefix?: string,
 ): Promise<void> {
-  debugger;
   let strings = await fetchRemoteStrings(
     distributionHash,
     locale,

--- a/src/localization/utils/load-crowdin-strings.ts
+++ b/src/localization/utils/load-crowdin-strings.ts
@@ -7,6 +7,7 @@ export async function loadCrowdinStrings(
   fallbackStrings?: object,
   prefix?: string,
 ): Promise<void> {
+  debugger;
   let strings = await fetchRemoteStrings(
     distributionHash,
     locale,

--- a/src/utils/is-instance.ts
+++ b/src/utils/is-instance.ts
@@ -15,6 +15,7 @@ export function isInstance(
     typeof value === 'object' &&
     !!value &&
     'constructor' in value &&
-    !!value.constructor
+    !!value.constructor &&
+    value.constructor !== Object
   );
 }


### PR DESCRIPTION
This PR adds a helper message that is shown below a duration picker to help users understand the right format for durations. It also fixes a bug in the `isInstance` function that caused the function to always return `true` because every JS object has a constructor named `Object` in their proto chain.