### PR TITLE
fix: i18n placeholders in Interval-based recurrence config form

### DIFF
--- a/src/components/dialogs/reccuring-closure-config-dialog/recurring-modes/interval-recurring-mode/IntervalConfigForm.tsx
+++ b/src/components/dialogs/reccuring-closure-config-dialog/recurring-modes/interval-recurring-mode/IntervalConfigForm.tsx
@@ -110,17 +110,17 @@ export function IntervalConfigForm(props: RecurringModeFormProps) {
 
       <wz-caption>
         {t('edit.closure.recurrence.interval.recurrence_explanation', {
-          closureDuration:
+          duration:
             isFinite(closureDuration) ?
               formatMinutes(closureDuration)
             : `<${t('edit.closure.recurrence.interval.closure_duration_label')}>`,
-          intervalBetweenClosures:
+          interval:
             isFinite(intervalBetweenClosures) ?
               formatMinutes(intervalBetweenClosures)
             : `<${t(
                 'edit.closure.recurrence.interval.interval_between_closures_label',
               )}>`,
-          anchorPoint: t(
+          anchor_point: t(
             'edit.closure.recurrence.interval.anchor_point_explanations',
           )[
             normalizeAnchorPoint(

--- a/src/components/dialogs/reccuring-closure-config-dialog/recurring-modes/interval-recurring-mode/enums/interval-anchor-point.ts
+++ b/src/components/dialogs/reccuring-closure-config-dialog/recurring-modes/interval-recurring-mode/enums/interval-anchor-point.ts
@@ -1,5 +1,5 @@
 export enum IntervalAnchorPoint {
   Default = 'DEFAULT',
-  StartOfPreviousClosure = 'START_OF_PREVIOUS_CLOSURE',
-  EndOfPreviousClosure = 'END_OF_PREVIOUS_CLOSURE',
+  StartOfPreviousClosure = 'CLOSURE_START',
+  EndOfPreviousClosure = 'CLOSURE_END',
 }


### PR DESCRIPTION
The Interval Config Dialog used in recurrence rules shows an explanation in human-readable text to provide clarity to the user on how actually the closures will be created. It used properties to surface the actual values, but the prop names were used in the wrong naming convention (`camelCase` as in normal JS in oppose to `snake_case` used in the localization file). This caused the `i18n` to not identify and substitute the props in the string, causing placeholders for missing prop values.

Additionally, the anchor point explanation keys in the localization file don't match the enum values we're relying on the provide translations.

Both have been fixed. The prop names in the JS code have been replaced with `snake_case`, and the enum values have been renamed to match the keys in the localization files.

Closes #55 