### PR TITLE
fix: extract TimePicker component and use bootstrap event handlers

### DIFF
--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -62,6 +62,7 @@ export const TimePicker = ({
     jQueryInput.on('blur.timepicker', () => {
       timePicker.setTime(input.value, true);
       timePicker.update();
+      onBlur?.(timePicker.getTime());
     });
 
     // Clean up event listeners when component unmounts

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, ComponentProps } from 'react';
+import { useMergeRefs } from '../hooks/useMergeRefs';
+
+interface TimePickerProps extends ComponentProps<'wz-text-input'> {
+  value?: string;
+  onChange?: (value: string) => void;
+  onBlur?: (value: string) => void;
+  timePickerOptions?: {
+    defaultTime?: boolean | string;
+    showMeridian?: boolean;
+    template?: boolean | string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+  };
+}
+
+export const TimePicker = ({
+  value = '',
+  onChange,
+  onBlur,
+  timePickerOptions = {},
+  ref,
+  ...props
+}: TimePickerProps) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Combine the external ref with our internal ref using useMergeRefs
+  const mergedRef = useMergeRefs(inputRef, ref);
+
+  // Initialize timepicker when the component mounts
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+
+    const jQueryInput = $(input) as JQuery<HTMLInputElement> & {
+      timepicker(options: object): void;
+    };
+
+    // Default options
+    const defaultOptions = {
+      defaultTime: false,
+      showMeridian: false,
+      template: false,
+    };
+
+    // Initialize timepicker with merged options
+    jQueryInput.timepicker({
+      ...defaultOptions,
+      ...timePickerOptions,
+    });
+
+    const timePicker = jQueryInput.data('timepicker');
+
+    // Set up event listeners for timepicker events
+    jQueryInput.on('changeTime.timepicker', () => {
+      const timeValue = timePicker.getTime();
+      if (timeValue && onChange) {
+        onChange(timeValue);
+      }
+    });
+
+    jQueryInput.on('blur.timepicker', () => {
+      timePicker.setTime(input.value, true);
+      timePicker.update();
+    });
+
+    // Clean up event listeners when component unmounts
+    return () => {
+      jQueryInput.off('changeTime.timepicker blur.timepicker');
+      timePicker.remove();
+    };
+  }, [onChange, onBlur, timePickerOptions]);
+
+  return (
+    <wz-text-input
+      ref={mergedRef}
+      value={value}
+      autocomplete="off"
+      {...props}
+    />
+  );
+};

--- a/src/components/closure-presets/preset-edit-dialog/steps/ClosureDetailsStep.tsx
+++ b/src/components/closure-presets/preset-edit-dialog/steps/ClosureDetailsStep.tsx
@@ -5,6 +5,7 @@ import { TimeOnly } from '../../../../classes';
 import { WeekdayFlags } from '../../../../enums';
 import { useTranslation } from '../../../../hooks';
 import { DurationPicker } from '../../../DurationPicker';
+import { TimePicker } from '../../../TimePicker';
 import { createUseStepState } from '../../../stepper';
 import { PositionAwareToggleButton } from '../../../ToggleButton';
 import { WeekdayPicker } from '../../../WeekdayPicker';
@@ -164,17 +165,7 @@ export function ClosureDetailsStep() {
             />
           </ToggleGroup>
 
-          <wz-text-input
-            ref={(input: HTMLInputElement) => {
-              const jQueryInput = $(input) as JQuery<HTMLInputElement> & {
-                timepicker(options: object): void;
-              };
-              jQueryInput.timepicker({
-                defaultTime: false,
-                showMeridian: false,
-                template: false,
-              });
-            }}
+          <TimePicker
             disabled={startTimeMode !== 'FIXED'}
             placeholder="--:--"
             value={
@@ -182,9 +173,19 @@ export function ClosureDetailsStep() {
                 `${startTime.getHours().toString().padStart(2, '0')}:${startTime.getMinutes().toString().padStart(2, '0')}`
               : ''
             }
-            onChange={(e: SyntheticEvent<HTMLInputElement, InputEvent>) =>
-              setStartTime(new TimeOnly(e.currentTarget.value))
-            }
+            onChange={(timeValue) => {
+              if (!timeValue) return;
+              setStartTime(new TimeOnly(timeValue));
+            }}
+            onBlur={(timeValue) => {
+              if (!timeValue) return;
+              setStartTime(new TimeOnly(timeValue));
+            }}
+            timePickerOptions={{
+              defaultTime: false,
+              showMeridian: false,
+              template: false,
+            }}
           />
         </div>
 
@@ -242,29 +243,32 @@ export function ClosureDetailsStep() {
           </ToggleGroup>
 
           {endTime?.type === 'FIXED' ?
-            <wz-text-input
-              ref={(input: HTMLInputElement) => {
-                const jQueryInput = $(input) as JQuery<HTMLInputElement> & {
-                  timepicker(options: object): void;
-                };
-                jQueryInput.timepicker({
-                  defaultTime: false,
-                  showMeridian: false,
-                  template: false,
-                });
-              }}
+            <TimePicker
               placeholder="--:--"
               value={
                 endTime.value ?
                   `${endTime.value.getHours().toString().padStart(2, '0')}:${endTime.value.getMinutes().toString().padStart(2, '0')}`
                 : ''
               }
-              onChange={(e: SyntheticEvent<HTMLInputElement, InputEvent>) =>
+              onChange={(timeValue) => {
+                if (!timeValue) return;
                 setEndTime({
                   type: 'FIXED',
-                  value: new TimeOnly(e.currentTarget.value),
-                })
-              }
+                  value: new TimeOnly(timeValue),
+                });
+              }}
+              onBlur={(timeValue) => {
+                if (!timeValue) return;
+                setEndTime({
+                  type: 'FIXED',
+                  value: new TimeOnly(timeValue),
+                });
+              }}
+              timePickerOptions={{
+                defaultTime: false,
+                showMeridian: false,
+                template: false,
+              }}
             />
           : endTime?.type === 'DURATIONAL' && (
               <DurationPicker


### PR DESCRIPTION
Extracting the TimePicker to its own component makes sense due to the massive logic with jQuery there.

Another issue is that we registered the `onChange` event for the input and updated the state on every keystroke, which is not compatible with the bootstrap's timepicker we were using (per Waze's implementation). It caused issues when trying to change the value of an already populated time picker field. To solve this bug, in the extracted component we register to the relevant bootstrap events that are fired after the user has done typing the new time and boostrap has processed the raw value.

Fixes #63 