### PR TITLE
fix: set the initial ` startTimeMode ` based on `startTime` state

### DIFF
--- a/src/components/closure-presets/preset-edit-dialog/steps/ClosureDetailsStep.tsx
+++ b/src/components/closure-presets/preset-edit-dialog/steps/ClosureDetailsStep.tsx
@@ -26,11 +26,11 @@ export function ClosureDetailsStep() {
   const { t } = useTranslation();
   const [description, setDescription] = useClosureDetailsState('description');
   const [startDate, setStartDate] = useClosureDetailsState('startDate');
-  const [startTimeMode, setStartTimeMode] = useState<'IMMEDIATE' | 'FIXED'>(
-    'IMMEDIATE',
-  );
   const [startTime, setStartTime] = useClosureDetailsState('startTime');
   const [endTime, setEndTime] = useClosureDetailsState('endTime');
+  const [startTimeMode, setStartTimeMode] = useState<'IMMEDIATE' | 'FIXED'>(
+    startTime ? 'FIXED' : 'IMMEDIATE',
+  );
 
   return (
     <PresetEditForm>


### PR DESCRIPTION
It solves the issue where editing a closure preset caused the start time mode selector to always start with the `IMMEDIATE` mode, regardless of the actual start time value.

Fixes #64