### PR TITLE
deps: update wme-sdk-typings version (v2.297-6-gdc60233f9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11802,9 +11802,9 @@
       }
     },
     "node_modules/wme-sdk-typings": {
-      "version": "v2.290-10-g58a886335",
+      "version": "v2.297-6-gdc60233f9",
       "resolved": "https://web-assets.waze.com/wme_sdk_docs/production/latest/wme-sdk-typings.tgz",
-      "integrity": "sha512-jsp6KQMrvbV/JbDY6gDpURDbdQoxPwzKo9Ccyjtb6yTh70GNZEqPxCO1gBbjQYb1UiC/7UEomDsmi2qqMQ6BNQ==",
+      "integrity": "sha512-JYYxrJ1rR2wUtlcgh3PHmLahVDf14P8T4GTWUXj2TIOLsszTyWomD/SO1IHjclCeiTTnHsvURcRHuhp6C8SV7w==",
       "dev": true,
       "license": "UNLICENSED",
       "peerDependencies": {


### PR DESCRIPTION
This pull requests updates the `wme-sdk-typings` package to the newest WME version available, fixes issues with CI pipelines where `npm` refuses to install the dependency because of integrity mismatch