### PR TITLE
refactor: add logging functionality to the script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "concurrently": "^9.1.2",
         "dexie": "^4.0.11",
         "dexie-react-hooks": "^1.1.7",
+        "js-logger": "^1.6.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "usehooks-ts": "^3.1.1"
@@ -9008,6 +9009,12 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/js-logger": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/js-logger/-/js-logger-1.6.1.tgz",
+      "integrity": "sha512-yTgMCPXVjhmg28CuUH8CKjU+cIKL/G+zTu4Fn4lQxs8mRFH/03QTNvEFngcxfg/gRDiQAOoyCKmMTOm9ayOzXA==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "concurrently": "^9.1.2",
     "dexie": "^4.0.11",
     "dexie-react-hooks": "^1.1.7",
+    "js-logger": "^1.6.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "usehooks-ts": "^3.1.1"

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -80,6 +80,7 @@ export default {
       __SCRIPT_CAMEL_CASE_NAME__: JSON.stringify(
         convertStringConvention(packagePureName, 'PascalCase'),
       ),
+      __SCRIPT_VERSION__: JSON.stringify(packageMetadata.version),
       __BUILD_TIME__: JSON.stringify(new Date()),
       'process.env.CROWDIN_DISTRIBUTION_HASH': JSON.stringify(
         process.env.CROWDIN_DISTRIBUTION_HASH || '15dd9243e7c0c5a4cad8d58031c',

--- a/src/build-time-variables.d.ts
+++ b/src/build-time-variables.d.ts
@@ -3,4 +3,5 @@ declare const __SCRIPT_AUTHOR__: string;
 declare const __SCRIPT_NAME__: string;
 declare const __SCRIPT_SHORT_NAME__: string;
 declare const __SCRIPT_CAMEL_CASE_NAME__: string;
+declare const __SCRIPT_VERSION__: string;
 declare const __BUILD_TIME__: string;

--- a/src/components/ScriptTab.tsx
+++ b/src/components/ScriptTab.tsx
@@ -1,14 +1,47 @@
-import { ReactNode, useEffect, useMemo, useState } from 'react';
+import {
+  ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { useWmeSdk } from '../contexts/WmeSdkContext';
 
-interface ScriptTabProps {
+type EffectCallback = (element: HTMLElement) => (() => void) | void;
+
+export interface ScriptTabProps {
   tabId?: string;
   tabLabel: ReactNode;
   children: ReactNode;
+  tabLabelEffect?: EffectCallback;
+  tabPaneEffect?: EffectCallback;
+  useLayoutEffectInstead?: boolean;
 }
-export function ScriptTab({ tabId, tabLabel, children }: ScriptTabProps) {
+export function ScriptTab({
+  tabId,
+  tabLabel,
+  children,
+  tabLabelEffect,
+  tabPaneEffect,
+  useLayoutEffectInstead = false,
+}: ScriptTabProps) {
   const tabElements = useScriptTabElements(tabId);
+
+  // Use the appropriate effect hook based on the useLayoutEffectInstead flag
+  const effectHook = useLayoutEffectInstead ? useLayoutEffect : useEffect;
+
+  // Apply effect to tabLabel element if provided
+  effectHook(() => {
+    if (!tabElements || !tabLabelEffect) return;
+    return tabLabelEffect(tabElements.tabLabel);
+  }, [tabElements, tabLabelEffect]);
+
+  // Apply effect to tabPane element if provided
+  effectHook(() => {
+    if (!tabElements || !tabPaneEffect) return;
+    return tabPaneEffect(tabElements.tabPane);
+  }, [tabElements, tabPaneEffect]);
 
   if (!tabElements) return null;
 

--- a/src/components/closure-presets/ClosurePresetEditorManager.tsx
+++ b/src/components/closure-presets/ClosurePresetEditorManager.tsx
@@ -1,7 +1,10 @@
+import Logger from 'js-logger';
 import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
 import { useClosurePresetsListContext } from '../../contexts';
 import { ClosurePreset, ClosurePresetMetadata } from '../../interfaces';
 import { PresetEditingDialog } from './preset-edit-dialog';
+
+const logger = Logger.get('preset-editor-manager');
 
 interface ClosurePresetEditorManager {
   openEditor(presetId?: ClosurePresetMetadata['id']): void;
@@ -31,6 +34,7 @@ export function ClosurePresetEditorManagerProvider({
 
     return {
       openEditor(presetId) {
+        logger.debug('Opening preset editor', { presetId });
         setEditingPreset(presetId ? getPresetById(presetId) : null);
         setIsEditing(true);
       },
@@ -44,15 +48,27 @@ export function ClosurePresetEditorManagerProvider({
         <PresetEditingDialog
           mode={editingPreset ? 'EDIT' : 'CREATE'}
           preset={editingPreset}
-          onCancel={() => setIsEditing(false)}
+          onCancel={() => {
+            logger.debug('Preset editor cancelled');
+            setIsEditing(false);
+          }}
           onComplete={async (newPresetValue) => {
+            logger.debug('Preset editor completed');
             setIsEditing(false);
 
             if (!editingPreset) {
+              logger.debug('Creating new preset', {
+                preset: newPresetValue,
+              });
               await createPreset(newPresetValue);
               return;
             }
 
+            logger.debug('Editing existing preset', {
+              presetId: editingPreset.id,
+              oldPreset: editingPreset,
+              newPresetDetails: newPresetValue,
+            });
             await updatePreset(editingPreset.id, {
               ...newPresetValue,
             });

--- a/src/components/dialogs/reccuring-closure-config-dialog/recurring-modes/interval-recurring-mode/interval-recurring-mode.ts
+++ b/src/components/dialogs/reccuring-closure-config-dialog/recurring-modes/interval-recurring-mode/interval-recurring-mode.ts
@@ -1,8 +1,11 @@
 import { Timeframe } from 'interfaces';
+import Logger from 'js-logger';
 import { RecurringMode } from '../recurring-mode';
 import { IntervalAnchorPoint } from './enums';
 import { IntervalConfigForm } from './IntervalConfigForm';
 import { getDefaultAnchorPoint } from './utils';
+
+const logger = Logger.get('INTERVAL_RECURRING_MODE');
 
 export interface IntervalModeFields {
   /** The length of each closure in minutes */
@@ -26,21 +29,60 @@ export const IntervalRecurringMode: RecurringMode<IntervalModeFields> = {
       anchorPoint = IntervalAnchorPoint.Default,
     },
   }) => {
+    logger.debug('Calculating interval-based closure times with parameters', {
+      timeframe: {
+        startDate: timeframe.startDate.toISOString(),
+        endDate: timeframe.endDate.toISOString(),
+      },
+      closureDuration,
+      intervalBetweenClosures,
+      anchorPoint,
+    });
+
     if (
       typeof closureDuration !== 'number' ||
       typeof intervalBetweenClosures !== 'number'
-    )
+    ) {
+      logger.error('Invalid field values', {
+        closureDuration,
+        intervalBetweenClosures,
+      });
       throw new Error('IntervalRecurringMode: Invalid field values');
+    }
 
     let nextClosureStartTime = timeframe.startDate;
+    logger.debug('Initial closure start time', {
+      nextClosureStartTime: nextClosureStartTime.toISOString(),
+    });
+
     const closureTimeframes: Timeframe[] = [];
 
+    let iterationCount = 0;
     while (true) {
+      iterationCount++;
+      logger.debug(`Processing iteration ${iterationCount}`);
+
       const nextClosureEndTime = addMinutes(
         nextClosureStartTime,
         closureDuration,
       );
-      if (nextClosureEndTime > timeframe.endDate) break;
+      logger.debug('Calculated next closure end time', {
+        nextClosureEndTime: nextClosureEndTime.toISOString(),
+        closureDuration,
+      });
+
+      if (nextClosureEndTime > timeframe.endDate) {
+        logger.debug('End time exceeds overall timeframe end, breaking loop', {
+          nextClosureEndTime: nextClosureEndTime.toISOString(),
+          overallEndTime: timeframe.endDate.toISOString(),
+        });
+        break;
+      }
+
+      logger.debug('Adding timeframe to results', {
+        startDate: nextClosureStartTime.toISOString(),
+        endDate: nextClosureEndTime.toISOString(),
+      });
       closureTimeframes.push({
         startDate: nextClosureStartTime,
         endDate: nextClosureEndTime,
@@ -48,16 +90,33 @@ export const IntervalRecurringMode: RecurringMode<IntervalModeFields> = {
 
       const targetAnchorPoint = (() => {
         if (anchorPoint !== IntervalAnchorPoint.Default) return anchorPoint;
-        return getDefaultAnchorPoint(closureDuration, intervalBetweenClosures);
+        const calculatedAnchorPoint = getDefaultAnchorPoint(
+          closureDuration,
+          intervalBetweenClosures,
+        );
+        logger.debug('Using default anchor point calculation', {
+          closureDuration,
+          intervalBetweenClosures,
+          calculatedAnchorPoint,
+        });
+        return calculatedAnchorPoint;
       })();
+      logger.debug('Using target anchor point', { targetAnchorPoint });
 
       const targetAnchorValue = (() => {
         switch (targetAnchorPoint) {
           case IntervalAnchorPoint.StartOfPreviousClosure:
+            logger.debug('Using start of previous closure as anchor', {
+              anchorValue: nextClosureStartTime.toISOString(),
+            });
             return nextClosureStartTime;
           case IntervalAnchorPoint.EndOfPreviousClosure:
+            logger.debug('Using end of previous closure as anchor', {
+              anchorValue: nextClosureEndTime.toISOString(),
+            });
             return nextClosureEndTime;
           default:
+            logger.error('Unexpected anchor point', { targetAnchorPoint });
             throw new Error(`Unexpected anchor point: ${targetAnchorPoint}`);
         }
       })();
@@ -66,7 +125,19 @@ export const IntervalRecurringMode: RecurringMode<IntervalModeFields> = {
         targetAnchorValue,
         intervalBetweenClosures,
       );
+      logger.debug('Calculated next closure start time', {
+        nextClosureStartTime: nextClosureStartTime.toISOString(),
+        intervalBetweenClosures,
+      });
     }
+
+    logger.debug('Returning interval-based timeframes', {
+      count: closureTimeframes.length,
+      timeframes: closureTimeframes.map((tf) => ({
+        startDate: tf.startDate.toISOString(),
+        endDate: tf.endDate.toISOString(),
+      })),
+    });
 
     return {
       timeframes: closureTimeframes,
@@ -75,7 +146,17 @@ export const IntervalRecurringMode: RecurringMode<IntervalModeFields> = {
 };
 
 function addMinutes(date: Date, minutes: number): Date {
+  logger.debug('Adding minutes to date', {
+    date: date.toISOString(),
+    minutes,
+  });
+
   const target = new Date(date);
   target.setMinutes(target.getMinutes() + minutes);
+
+  logger.debug('Result after adding minutes', {
+    result: target.toISOString(),
+  });
+
   return target;
 }

--- a/src/consts/date-resolvers/day-of-week-resolver.ts
+++ b/src/consts/date-resolvers/day-of-week-resolver.ts
@@ -1,6 +1,9 @@
 import { WeekdayFlags } from 'enums';
+import Logger from 'js-logger';
 import { createDateResolver } from './date-resolver';
 import { DateOnly } from 'classes';
+
+const logger = Logger.get('DAY_OF_WEEK_RESOLVER');
 
 interface DayOfWeekResolverArgs {
   /** The numeric representation of the day(s) of the week, to be used with the {@link WeekdayFlags} bitwise enum. */
@@ -45,13 +48,25 @@ export const DAY_OF_WEEK_RESOLVER = createDateResolver(
     const { dayOfWeek } = args;
     const flags = new WeekdayFlags(dayOfWeek);
 
-    const nextOccurrences = flags.getActiveBasicFlags().map((dayFlagValue) => {
+    logger.debug('Resolving to date using args', { dayOfWeek });
+
+    const basicFlagValues = flags.getActiveBasicFlags();
+    logger.debug('Extracted active basic flags', { value: basicFlagValues });
+    const nextOccurrences = basicFlagValues.map((dayFlagValue) => {
       const dayIndex = dayFlagToDayIndex(dayFlagValue);
       const today = new Date();
       const todayDayOfWeek = today.getUTCDay();
       const daysUntilNextOccurrence = (dayIndex + 7 - todayDayOfWeek) % 7 || 7; // If it's today, go to next week
       const nextOccurrence = new DateOnly(today);
       nextOccurrence.setUTCDate(today.getUTCDate() + daysUntilNextOccurrence);
+      logger.debug('Calculating for day index', {
+        dayIndex,
+        dayFlagValue,
+        today: today.toISOString(),
+        todayDayOfWeek,
+        daysUntilNextOccurrence,
+        nextOccurrence: nextOccurrence.toISOString(),
+      });
       return nextOccurrence;
     });
 

--- a/src/consts/session-id.ts
+++ b/src/consts/session-id.ts
@@ -1,0 +1,6 @@
+const SESSION_ID_LENGTH = 12;
+const SESSION_RADIX = 36;
+
+const randomSeed = Math.random();
+const randomValue = Math.floor(randomSeed * SESSION_RADIX ** SESSION_ID_LENGTH);
+export const SessionId = randomValue.toString(36);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,13 +47,19 @@ axios.defaults.adapter = axiosGmXhrAdapter;
 
 const [wmeSdk] = await Promise.all([
   await (async () => {
+    Logger.debug('Waiting for SDK to initialize...');
     await SDK_INITIALIZED;
-    return await initWmeSdkPlus(
+    const wmeSdk = await initWmeSdkPlus(
       getWmeSdk({
         scriptId: __SCRIPT_ID__,
         scriptName: __SCRIPT_NAME__,
       }),
     );
+    Logger.debug('SDK initialized.', {
+      username: wmeSdk.State.getUserInfo()?.userName,
+      userRank: wmeSdk.State.getUserInfo()?.rank,
+    });
+    return wmeSdk;
   })(),
   await loadCrowdinStrings(
     getCurrentLocale(),
@@ -63,6 +69,7 @@ const [wmeSdk] = await Promise.all([
   ),
 ]);
 
+Logger.debug('Starting app...');
 const root = createRoot(document.createDocumentFragment());
 const AppWrapper = asScriptTab(
   App,
@@ -82,3 +89,5 @@ root.render(
     wmeSdk,
   }),
 );
+
+Logger.debug('Rendered. Idle');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import { WzMenuElement } from 'types/waze/elements';
 
 import './utils/wme-date-format';
 
+const sessionLogs = [];
 const consoleLogger = (() => {
   let lastConsoleOutput = NaN;
 
@@ -37,6 +38,11 @@ const consoleLogger = (() => {
 })();
 Logger.setHandler((messages, context) => {
   consoleLogger(messages, context);
+  sessionLogs.push({
+    time: new Date().toISOString(),
+    context,
+    messages,
+  });
 });
 
 Logger.setLevel(Logger.DEBUG);
@@ -131,7 +137,7 @@ root.render(
           timestamp: new Date().toISOString(),
           userInfo: wmeSdk.State.getUserInfo(),
           browserInfo,
-          content: null,
+          content: sessionLogs,
         };
 
         const logBlob = new Blob([JSON.stringify(logData, null, 2)], {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 import axios from 'axios';
+import Logger from 'js-logger';
 import { createRoot } from 'react-dom/client';
+import { SessionId } from './consts/session-id';
 import { getCurrentLocale, loadCrowdinStrings } from './localization';
 import fallbackStrings from './localization/static/userscript.json';
 import { axiosGmXhrAdapter } from './tampermonkey/axios-gmxhr-adapter';
@@ -10,6 +12,36 @@ import { createElement } from 'react';
 import PlusBranded from './assets/plus-branded.svg';
 
 import './utils/wme-date-format';
+
+const consoleLogger = (() => {
+  let lastConsoleOutput = NaN;
+
+  return Logger.createDefaultHandler({
+    formatter: (messages, context) => {
+      const currentTime = new Date();
+      const timeSinceLastMessage = currentTime.getTime() - lastConsoleOutput;
+      messages.unshift(
+        [
+          '[editorx.dev/closures-plus]',
+          currentTime.toISOString(),
+          !isNaN(timeSinceLastMessage) &&
+            `\x1B[32m+${timeSinceLastMessage}ms\x1B[m`,
+          context.name && `[\x1B[105;1m${context.name}\x1B[m]`,
+        ]
+          .filter(Boolean)
+          .join('\t'),
+      );
+      lastConsoleOutput = currentTime.getTime();
+    },
+  });
+})();
+Logger.setHandler((messages, context) => {
+  consoleLogger(messages, context);
+});
+
+Logger.setLevel(Logger.DEBUG);
+Logger.debug('Logger initialized.');
+Logger.debug('Starting session', { sessionId: SessionId });
 
 axios.defaults.adapter = axiosGmXhrAdapter;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,8 +8,8 @@ import { axiosGmXhrAdapter } from './tampermonkey/axios-gmxhr-adapter';
 import { getWmeSdk, SDK_INITIALIZED } from './utils/sdk-utils';
 import { App } from './App';
 import { asScriptTab } from 'utils/as-script-tab';
-import { createElement } from 'react';
 import PlusBranded from './assets/plus-branded.svg';
+import { WzMenuElement } from 'types/waze/elements';
 
 import './utils/wme-date-format';
 
@@ -41,7 +41,21 @@ Logger.setHandler((messages, context) => {
 
 Logger.setLevel(Logger.DEBUG);
 Logger.debug('Logger initialized.');
-Logger.debug('Starting session', { sessionId: SessionId });
+Logger.debug('Starting session', {
+  sessionId: SessionId,
+  version: __SCRIPT_VERSION__,
+  buildTime: __BUILD_TIME__,
+  browserInfo: {
+    userAgent: navigator.userAgent,
+    language: navigator.language,
+    platform: navigator.platform,
+    screenWidth: window.screen.width,
+    screenHeight: window.screen.height,
+    windowWidth: window.innerWidth,
+    windowHeight: window.innerHeight,
+  },
+  initialUrl: window.location.href,
+});
 
 axios.defaults.adapter = axiosGmXhrAdapter;
 
@@ -58,6 +72,11 @@ const [wmeSdk] = await Promise.all([
     Logger.debug('SDK initialized.', {
       username: wmeSdk.State.getUserInfo()?.userName,
       userRank: wmeSdk.State.getUserInfo()?.rank,
+      wazeMapEditorInfo: {
+        version: wmeSdk.getWMEVersion(),
+        sdkVersion: wmeSdk.getSDKVersion(),
+        isBetaEnv: wmeSdk.isBetaEnvironment(),
+      },
     });
     return wmeSdk;
   })(),
@@ -85,9 +104,138 @@ const AppWrapper = asScriptTab(
 );
 
 root.render(
-  createElement(AppWrapper, {
-    wmeSdk,
-  }),
+  <AppWrapper
+    wmeSdk={wmeSdk}
+    tabLabelEffect={(tabLabelElement) => {
+      let clickCount = 0;
+      let lastClickTime = 0;
+      const CLICK_TIMEOUT = 3000;
+
+      const sendLogs = () => {
+        Logger.debug('Sending logs...');
+
+        // Collect browser and environment information
+        const browserInfo = {
+          userAgent: navigator.userAgent,
+          language: navigator.language,
+          platform: navigator.platform,
+          screenWidth: window.screen.width,
+          screenHeight: window.screen.height,
+          windowWidth: window.innerWidth,
+          windowHeight: window.innerHeight,
+        };
+
+        // Create a text blob with logs
+        const logData = {
+          sessionId: SessionId,
+          timestamp: new Date().toISOString(),
+          userInfo: wmeSdk.State.getUserInfo(),
+          browserInfo,
+          content: null,
+        };
+
+        const logBlob = new Blob([JSON.stringify(logData, null, 2)], {
+          type: 'application/json',
+        });
+        const url = URL.createObjectURL(logBlob);
+
+        // Create a download link
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `wme-closures-plus-logs-${new Date().toISOString()}.json`;
+        document.body.appendChild(a);
+        a.click();
+
+        // Clean up
+        setTimeout(() => {
+          document.body.removeChild(a);
+          URL.revokeObjectURL(url);
+        }, 100);
+
+        Logger.debug('Logs sent');
+      };
+
+      const handleContextMenu = (event: MouseEvent) => {
+        const currentTime = Date.now();
+
+        // Check if the click is within the timeout period
+        if (currentTime - lastClickTime > CLICK_TIMEOUT) {
+          // Reset if timeout exceeded
+          clickCount = 0;
+        }
+
+        clickCount++;
+        lastClickTime = currentTime;
+
+
+        if (clickCount === 5) {
+          Logger.debug('Context menu triggered', { event });
+          // Prevent default context menu on third click
+          event.preventDefault();
+
+          // Reset counter
+          clickCount = 0;
+
+          // Create wz-menu element if it doesn't exist
+          let menu = document.querySelector(
+            'wz-menu#editorx-wme-closures-plus-debug-menu',
+          ) as WzMenuElement;
+          if (!menu) {
+            menu = document.createElement('wz-menu') as WzMenuElement;
+            menu.id = 'editorx-wme-closures-plus-debug-menu';
+            menu.setAttribute('fixed', 'true');
+
+            // Create menu items
+            const downloadLogsItem = document.createElement('wz-menu-item');
+            downloadLogsItem.innerHTML = 'Download Logs';
+            downloadLogsItem.addEventListener('click', sendLogs);
+
+            // Add divider before version info
+            const divider = document.createElement('wz-menu-divider');
+
+            // Create debug info item (non-clickable)
+            const debugInfoItem = document.createElement('div');
+            debugInfoItem.style.padding =
+              'var(--wz-menu-option-padding, var(--space-always-s, 12px))';
+            debugInfoItem.style.minHeight =
+              'var(--wz-menu-option-height, var(--wz-option-height, 40px))';
+            debugInfoItem.innerHTML = `
+              <wz-overline>${__SCRIPT_SHORT_NAME__} Debug Menu</wz-overline>
+              <div style="display: flex; flex-direction: column">
+                <wz-caption>Version: ${__SCRIPT_VERSION__}</wz-caption>
+                <wz-caption>Build time: ${__BUILD_TIME__}</wz-caption>
+              </div>
+            `;
+
+            // Add items to menu
+            menu.appendChild(downloadLogsItem);
+            menu.appendChild(divider);
+            menu.appendChild(debugInfoItem);
+
+            // Add menu to document
+            document.body.appendChild(menu);
+          }
+
+          menu.showMenu(event);
+        }
+      };
+
+      tabLabelElement.addEventListener('pointerup', handleContextMenu);
+
+      // Return cleanup function
+      return () => {
+        tabLabelElement.removeEventListener('pointerup', handleContextMenu);
+
+        // Remove the menu element if it exists
+        const menu = document.querySelector(
+          'wz-menu#editorx-wme-closures-plus-debug-menu',
+        );
+        if (menu && menu.parentNode) {
+          menu.parentNode.removeChild(menu);
+        }
+      };
+    }}
+  />,
 );
 
 Logger.debug('Rendered. Idle');

--- a/src/localization/utils/load-crowdin-strings.ts
+++ b/src/localization/utils/load-crowdin-strings.ts
@@ -1,5 +1,8 @@
+import Logger from 'js-logger';
 import { fetchRemoteStrings } from './fetch-remote-strings';
 import { loadStrings } from './load-strings';
+
+const logger = Logger.get('i18n');
 
 export async function loadCrowdinStrings(
   locale: string,
@@ -7,6 +10,11 @@ export async function loadCrowdinStrings(
   fallbackStrings?: object,
   prefix?: string,
 ): Promise<void> {
+  logger.debug(`Loading strings from crowdin`, {
+    distributionHash,
+    locale,
+  });
+
   let strings = await fetchRemoteStrings(
     distributionHash,
     locale,

--- a/src/types/waze/elements/wz-menu.ts
+++ b/src/types/waze/elements/wz-menu.ts
@@ -1,3 +1,4 @@
 export interface WzMenuElement extends HTMLElement {
   toggleMenu(event?: MouseEvent): void;
+  showMenu(event?: MouseEvent): void;
 }

--- a/src/utils/apply-closure-preset.ts
+++ b/src/utils/apply-closure-preset.ts
@@ -2,29 +2,60 @@ import { ClosureEditorForm, DateOnly } from 'classes';
 import { TimeOnly } from 'classes';
 import { getDateResolverByName } from 'consts/date-resolvers';
 import { ClosurePreset } from 'interfaces/closure-preset';
+import Logger from 'js-logger';
+
+const logger = Logger.get('closure-presets');
 
 function getStartDateForPreset(
   closureDetails: ClosurePreset['closureDetails'],
   defaultStartDate: DateOnly = new DateOnly(),
 ): Date {
-  const date =
-    closureDetails.startDate ?
-      getDateResolverByName(closureDetails.startDate.type).resolve(
-        closureDetails.startDate.args,
-      )
-    : defaultStartDate;
+  logger.debug('Getting start timestamp for preset');
 
-  const time =
-    closureDetails.startTime ?
-      new TimeOnly(
-        closureDetails.startTime.hours,
-        closureDetails.startTime.minutes,
-        0,
-        0,
-      )
-    : new TimeOnly();
+  const date = ((): DateOnly => {
+    if (!closureDetails.startDate) {
+      logger.debug('No specific start date supplied. Using default', {
+        default: defaultStartDate.toISOString(),
+      });
+      return defaultStartDate;
+    }
 
-  return date.withTime(time);
+    logger.debug('Using date resolver to get start date', {
+      resolver: closureDetails.startDate.type,
+    });
+    const result = getDateResolverByName(closureDetails.startDate.type).resolve(
+      closureDetails.startDate.args,
+    );
+    logger.debug('Resolved start date', {
+      resolver: closureDetails.startDate.type,
+      result: result.toISOString(),
+    });
+    return result;
+  })();
+
+  const time = ((): TimeOnly => {
+    if (!closureDetails.startTime) {
+      logger.debug('No specific start time supplied. Using current time');
+      return new TimeOnly();
+    }
+
+    logger.debug('Using specified time as start time', {
+      hours: closureDetails.startTime.hours,
+      minutes: closureDetails.startTime.minutes,
+    });
+    return new TimeOnly(
+      closureDetails.startTime.hours,
+      closureDetails.startTime.minutes,
+      0,
+      0,
+    );
+  })();
+
+  const result = date.withTime(time);
+  logger.debug('Resolved starting timestamp', {
+    value: result.toISOString(),
+  });
+  return result;
 }
 
 function getEndDateForPreset(
@@ -32,6 +63,10 @@ function getEndDateForPreset(
   startDate: Date,
 ): Date {
   const { end: endDetails } = closureDetails;
+
+  logger.debug('Getting end timestamp for preset', {
+    value: endDetails,
+  });
 
   switch (endDetails.type) {
     case 'DURATIONAL':
@@ -57,6 +92,13 @@ function getEndDateForPreset(
         endTime.getMilliseconds(),
       );
       if (endTime < startTime) {
+        logger.debug(
+          'Using fixed end time. End time is earlier than the start time, probably referring to the next day. Advances the date',
+          {
+            startTime: startTime.toString(),
+            endTime: endTime.toString(),
+          },
+        );
         // we need to apply the end time to the next day
         endDate.setDate(endDate.getDate() + 1);
       }
@@ -70,18 +112,31 @@ function getEndDateForPreset(
 }
 
 export function applyClosurePreset(
-  { closureDetails }: ClosurePreset,
+  { closureDetails, ...restPreset }: ClosurePreset,
   closureEditorForm: ClosureEditorForm,
 ) {
+  logger.debug('Beginning to apply a closure preset', {
+    presetMeta: restPreset,
+    closureDetails,
+  });
+
   const startDate = getStartDateForPreset(
     closureDetails,
     new DateOnly(closureEditorForm.getStart()),
   );
   const endDate = getEndDateForPreset(closureDetails, startDate);
 
-  if (closureDetails.description)
+  if (closureDetails.description) {
+    logger.log('Preset has a description. Applying..');
     closureEditorForm.setDescription(closureDetails.description);
+  }
 
+  logger.log('Applying resolved start timestamp', {
+    value: startDate.toISOString(),
+  });
   closureEditorForm.setStart(startDate);
+  logger.log('Applying resolved end timestamp', {
+    value: endDate.toISOString(),
+  });
   closureEditorForm.setEnd(endDate);
 }

--- a/src/utils/as-script-tab.tsx
+++ b/src/utils/as-script-tab.tsx
@@ -4,23 +4,40 @@ import {
   FunctionComponent,
   ReactElement,
 } from 'react';
-import { ScriptTab } from '../components/ScriptTab';
+import { ScriptTab, ScriptTabProps } from '../components/ScriptTab';
 import { getDisplayName } from './get-display-name';
 
 type DirectReactChildren = ReactElement | string | number;
 
+type InheritedScriptTabProps = Pick<
+  ScriptTabProps,
+  'tabLabelEffect' | 'tabPaneEffect' | 'useLayoutEffectInstead'
+>;
+
 export function asScriptTab<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   C extends ComponentType<any>,
-  P extends object = ComponentProps<C>,
+  P extends InheritedScriptTabProps = ComponentProps<C> &
+    InheritedScriptTabProps,
 >(
   Component: C,
   tabLabel: DirectReactChildren,
   tabId?: string,
 ): FunctionComponent<P> {
-  const tabbedComponent = (props: P) => {
+  const tabbedComponent = ({
+    tabLabelEffect,
+    tabPaneEffect,
+    useLayoutEffectInstead,
+    ...props
+  }: P) => {
     return (
-      <ScriptTab tabId={tabId} tabLabel={tabLabel}>
+      <ScriptTab
+        tabId={tabId}
+        tabLabel={tabLabel}
+        tabLabelEffect={tabLabelEffect}
+        tabPaneEffect={tabPaneEffect}
+        useLayoutEffectInstead={useLayoutEffectInstead}
+      >
         {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
         {/*// @ts-expect-error */}
         <Component {...props} />


### PR DESCRIPTION
Logs are essential for debugging information that occurs on users' side. Closures+ lacks this ability, this pull request is intended to add it.

### Differentiating between sessions

For each session of the script it generates a random session ID (numeric) which is then stringified to the base of 36 (0-9, a-z). The length for the session ID is set to 12 chars long.

### Information Logged

This pull request adds logging to these script functions:

- Closure Presets: Specific day of week date resolver
- Closure Presets: Application process
- Closure Presets: Preset Editor Dialog opens/completes/cancels
- General: Session generation (ID). Logger initialization
- General: SDK initialization
- General: App rendering
- General: Crowdin localization strings download
- Recurring Closures: Both recurring modes: Daily and Interval

### Log Submission

A new hidden context menu is added to the script tab, activated by clicking 5 times on the tab label. The context menu shows a summary of debug info and a button to download logs. The logs are in JSON format and will include all messages printed so far by the session along with some browser and SDK metadata. It won't persist between sessions.