### PR TITLE
fix(CP): preset dropdown is small when in turn closure card

### DIFF
--- a/src/components/portals/closure-editor-panel/ClosureEditorGroup.tsx
+++ b/src/components/portals/closure-editor-panel/ClosureEditorGroup.tsx
@@ -10,17 +10,28 @@ const groupClass = css({
 const groupWithBorderClass = css({
   borderBottom: '1px solid var(--hairline)',
 });
+const disableTopPaddingClass = css({
+  paddingTop: 'unset',
+});
 
 interface ClosureEditorGroupProps {
+  disableTopPadding?: boolean;
   hasBorder?: boolean;
   children: ReactNode;
 }
 export function ClosureEditorGroup({
+  disableTopPadding,
   hasBorder,
   children,
 }: ClosureEditorGroupProps) {
   return (
-    <div className={clsx(groupClass, hasBorder && groupWithBorderClass)}>
+    <div
+      className={clsx(
+        groupClass,
+        hasBorder && groupWithBorderClass,
+        disableTopPadding && disableTopPaddingClass,
+      )}
+    >
       {children}
     </div>
   );

--- a/src/components/portals/closure-editor-panel/ClosureEditorGroup.tsx
+++ b/src/components/portals/closure-editor-panel/ClosureEditorGroup.tsx
@@ -4,6 +4,8 @@ import { ReactNode } from 'react';
 
 const groupClass = css({
   padding: 'var(--trimmed-padding)',
+  width: '100%',
+  flex: '1 1 auto', // Make it grow and take all available space in flexbox context
 });
 const groupWithBorderClass = css({
   borderBottom: '1px solid var(--hairline)',

--- a/src/components/portals/closure-editor-panel/ClosureEditorPanel.tsx
+++ b/src/components/portals/closure-editor-panel/ClosureEditorPanel.tsx
@@ -4,7 +4,7 @@ import {
   ClosureEditorFormContextConsumer,
   ClosureEditorFormContextProvider,
 } from 'contexts';
-import { useChangeTabPadding, useTranslation } from 'hooks';
+import { useChangeContainerPadding, useTranslation } from 'hooks';
 import { ClosureEditorGroup } from './ClosureEditorGroup';
 import { ClosurePresetDropdown } from 'components/closure-presets/ClosurePresetDropdown';
 import { applyClosurePreset } from 'utils';
@@ -14,22 +14,41 @@ interface ClosureEditorPanelProps {
 }
 function ClosureEditorPanel(props: ClosureEditorPanelProps) {
   const { t } = useTranslation();
+  // Look for either wz-tab or wz-card, as different UIs might use different components
   const closestTab = props.target.closest<HTMLElement>('wz-tab');
-  const originalPadding = useChangeTabPadding(closestTab, 0);
-  if (originalPadding) {
-    closestTab?.style?.setProperty?.(
+  const closestCard = props.target.closest<HTMLElement>('wz-card');
+  const containerElement = closestTab || closestCard;
+
+  const originalPadding = useChangeContainerPadding(containerElement, 0);
+  if (originalPadding && containerElement) {
+    containerElement.style.setProperty(
       '--trimmed-padding',
       originalPadding.map((p) => `${p.value}${p.unit}`).join(' '),
     );
+    // Restore padding to the target element
+    props.target.style.padding = `var(--trimmed-padding)`;
+    // Recursively find all elements to whom we need to apply the padding
+    // These are the siblings of the target element, and siblings of their respective parents (up to the container)
+    let parent = props.target.parentElement,
+      triggerer = props.target;
+    while (parent) {
+      Array.from(parent.children).forEach((child) => {
+        if (child instanceof HTMLElement && child !== triggerer) {
+          child.style.padding = `var(--trimmed-padding)`;
+        }
+      });
+      triggerer = parent;
+      parent = parent.parentElement;
+      if (parent === containerElement) break;
+    }
   }
-  props.target.style.padding = `var(--trimmed-padding)`;
 
   return (
     <ClosureEditorFormContextProvider
       type="CLOSURES_GROUP_MODEL_DOM_FORM"
       target={props.target as HTMLFormElement}
     >
-      <ClosureEditorGroup hasBorder>
+      <ClosureEditorGroup hasBorder disableTopPadding={!!closestCard}>
         <ClosureEditorFormContextConsumer>
           {(closureEditorForm) => (
             <ClosurePresetDropdown

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,4 @@
-export * from './useChangeTabPadding';
+export * from './useChangeContainerPadding';
 export * from './useQuerySelectorAll';
 export * from './useSet';
 export * from './useTranslation';

--- a/src/hooks/useChangeContainerPadding.ts
+++ b/src/hooks/useChangeContainerPadding.ts
@@ -11,14 +11,14 @@ type PaddingComponentValue =
   | `${number}${CSSUnit}`
   | PaddingComponentStructuredValue;
 
-export function useChangeTabPadding(
-  tabElement: HTMLElement,
+export function useChangeContainerPadding(
+  containerElement: HTMLElement,
   newPadding: PaddingComponentValue[] | string | number,
 ): PaddingComponentStructuredValue[] | null {
-  const tabContainer = useTabShadowELement(tabElement);
+  const container = useShadowElement(containerElement);
 
   const originalPadding =
-    tabContainer ? getComputedStyle(tabContainer).padding : null;
+    container ? getComputedStyle(container).padding : null;
   const paddingValues =
     originalPadding ? parsePaddingValue(originalPadding) : null;
 
@@ -43,14 +43,14 @@ export function useChangeTabPadding(
     })();
 
     // Apply the new padding values
-    if (tabContainer)
-      tabContainer.style.padding = `${newPaddingValues.map((val) => `${val.value}${val.unit}`).join(' ')}`;
+    if (container)
+      container.style.padding = `${newPaddingValues.map((val) => `${val.value}${val.unit}`).join(' ')}`;
 
     return () => {
       // Reset to original padding on cleanup
-      if (tabContainer) tabContainer.style.padding = originalPadding;
+      if (container) container.style.padding = originalPadding;
     };
-  }, [tabContainer, newPadding, originalPadding]);
+  }, [container, newPadding, originalPadding]);
 
   return paddingValues;
 }
@@ -70,14 +70,20 @@ function parsePaddingValue(value: string): PaddingComponentStructuredValue[] {
   return paddingValues;
 }
 
-function useTabShadowELement(tabElement: HTMLElement): HTMLElement | null {
-  if (tabElement?.tagName !== 'WZ-TAB') return null;
+function useShadowElement(element: HTMLElement): HTMLElement | null {
+  if (!element) return null;
 
-  const shadowRoot = tabElement.shadowRoot;
+  // Check if the element is either a WZ-TAB or WZ-CARD
+  if (element.tagName !== 'WZ-TAB' && element.tagName !== 'WZ-CARD')
+    return null;
+
+  const shadowRoot = element.shadowRoot;
   if (!shadowRoot) return null;
 
-  const tabContainer: HTMLElement = shadowRoot.querySelector('.wz-tab');
-  if (!tabContainer) return null;
+  // Select the appropriate container based on the element type
+  const selector = element.tagName === 'WZ-TAB' ? '.wz-tab' : '.wz-card';
+  const container: HTMLElement = shadowRoot.querySelector(selector);
+  if (!container) return null;
 
-  return tabContainer;
+  return container;
 }

--- a/src/hooks/useChangeContainerPadding.ts
+++ b/src/hooks/useChangeContainerPadding.ts
@@ -23,6 +23,18 @@ export function useChangeContainerPadding(
     originalPadding ? parsePaddingValue(originalPadding) : null;
 
   useLayoutEffect(() => {
+    if (!container) return;
+
+    const originalOverflow = getComputedStyle(container).overflow;
+
+    container.style.overflow = 'hidden';
+
+    return () => {
+      container.style.overflow = originalOverflow;
+    };
+  }, [container]);
+
+  useLayoutEffect(() => {
     const newPaddingValues = (() => {
       if (typeof newPadding === 'string') return parsePaddingValue(newPadding);
       if (typeof newPadding === 'number')


### PR DESCRIPTION
## Overview

This pull request fixes the bug occurring in the turn closure card, where the preset selection dropdown is small and doesn't follow the stylings as in the segment's closure layout. Additionally, and not mentioned in the bug report (#69), the padding workaround we are using for the tab layout in segment closures (to add the border at the bottom) doesn't work in the turn closure layout because it uses `wz-card` and not `wz-tab`.

## Changes

To solve this issue, which occurs because the turn closure card uses flexbox layout, we applied additional CSS stylings to the `ClosureEditorGroup` component: `style` and `flex` properties to stretch to the full width available. It solved the issue of the size.

To solve the second issue of the padding, the hook `useChangeTabPadding` has been renamed to `useChangeContainerPadding`, and as the name suggests, it now handles both `WZ-TAB` and `WZ-CARD` elements. It also defines an `overflow: hidden` to hide artifacts of border-radius, which expect the content to be padded. Additionally, some changes within the `ClosureEditorPanel` component were required to restore the padding to siblings of the `target` rather than only to the `target` itself. This is because the turn closure card renders more elements, like the card popup header. The recursive implementation there finds all elements up to the card/tab container and updates the padding if necessary.

Lastly, to accommodate the turn closure's header which also has padding, but not the content itself (natively), a new prop to the `ClosureEditorGroup` has been added to remove the padding on top.

Fixes #69