### PR TITLE
fix(CP): preset is applied to a past date

### DIFF
--- a/src/classes/date-only.spec.ts
+++ b/src/classes/date-only.spec.ts
@@ -1,41 +1,39 @@
 import { DateOnly } from './date-only';
 import { TimeOnly } from './time-only';
 
-const FIXED_DATE = new Date('2023-01-01T18:41:00Z');
-
 describe('DateOnly', () => {
   beforeAll(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(FIXED_DATE); // Set a fixed date for testing
+    jest.setSystemTime(new Date(2023, 0, 1, 18, 41, 0, 0)); // Set a fixed date for testing
   });
 
   it('should create an instance with the current date when no arguments are provided', () => {
     const dateOnly = new DateOnly();
     const now = new Date();
-    expect(dateOnly.getUTCDate()).toBe(now.getUTCDate());
-    expect(dateOnly.getUTCMonth()).toBe(now.getUTCMonth());
-    expect(dateOnly.getUTCFullYear()).toBe(now.getUTCFullYear());
-    expect(dateOnly.getUTCDay()).toBe(now.getUTCDay());
+    expect(dateOnly.getDate()).toBe(now.getDate());
+    expect(dateOnly.getMonth()).toBe(now.getMonth());
+    expect(dateOnly.getFullYear()).toBe(now.getFullYear());
+    expect(dateOnly.getDay()).toBe(now.getDay());
     expect(dateOnly.toISOString()).toBe(now.toISOString().split('T')[0]);
   });
 
   it('should create an instance with a specific Date object', () => {
-    const date = new Date('2023-01-01T00:00:00Z');
+    const date = new Date(2023, 1, 21, 13, 44, 0, 0);
     const dateOnly = new DateOnly(date);
-    expect(dateOnly.getUTCDate()).toBe(date.getUTCDate());
-    expect(dateOnly.getUTCMonth()).toBe(date.getUTCMonth());
-    expect(dateOnly.getUTCFullYear()).toBe(date.getUTCFullYear());
-    expect(dateOnly.getUTCDay()).toBe(date.getUTCDay());
-    expect(dateOnly.toISOString()).toBe('2023-01-01');
+    expect(dateOnly.getDate()).toBe(date.getDate());
+    expect(dateOnly.getMonth()).toBe(date.getMonth());
+    expect(dateOnly.getFullYear()).toBe(date.getFullYear());
+    expect(dateOnly.getDay()).toBe(date.getDay());
+    expect(dateOnly.toISOString()).toBe('2023-02-21');
   });
 
   it('should create an instance with a specific timestamp', () => {
-    const timestamp = Date.UTC(2023, 0, 1);
+    const timestamp = new Date(2023, 0, 1).getTime();
     const dateOnly = new DateOnly(timestamp);
-    expect(dateOnly.getUTCDate()).toBe(1);
-    expect(dateOnly.getUTCMonth()).toBe(0);
-    expect(dateOnly.getUTCFullYear()).toBe(2023);
-    expect(dateOnly.getUTCDay()).toBe(0);
+    expect(dateOnly.getDate()).toBe(1);
+    expect(dateOnly.getMonth()).toBe(0);
+    expect(dateOnly.getFullYear()).toBe(2023);
+    expect(dateOnly.getDay()).toBe(0);
     expect(dateOnly.toISOString()).toBe('2023-01-01');
   });
 
@@ -64,32 +62,12 @@ describe('DateOnly', () => {
     expect(dateOnly.toJSON()).toBe('2023-01-01');
   });
 
-  it('should return the correct UTC date components', () => {
-    const dateOnly = new DateOnly('2023-01-01');
-    expect(dateOnly.getUTCDate()).toBe(1);
-    expect(dateOnly.getUTCMonth()).toBe(0);
-    expect(dateOnly.getUTCFullYear()).toBe(2023);
-    expect(dateOnly.getUTCDay()).toBe(0);
-  });
-
   it('should return the correct local date components', () => {
     const dateOnly = new DateOnly('2023-01-01');
     expect(dateOnly.getDate()).toBe(1);
     expect(dateOnly.getMonth()).toBe(0);
     expect(dateOnly.getFullYear()).toBe(2023);
     expect(dateOnly.getDay()).toBe(0);
-  });
-
-  it('should set and return the correct UTC date components', () => {
-    const dateOnly = new DateOnly('2023-01-01');
-    dateOnly.setUTCDate(2);
-    expect(dateOnly.getUTCDate()).toBe(2);
-
-    dateOnly.setUTCMonth(1);
-    expect(dateOnly.getUTCMonth()).toBe(1);
-
-    dateOnly.setUTCFullYear(2024);
-    expect(dateOnly.getUTCFullYear()).toBe(2024);
   });
 
   it('should set and return the correct local date components', () => {
@@ -112,7 +90,7 @@ describe('DateOnly', () => {
   it('should return a new Date object with the correct value', () => {
     const dateOnly = new DateOnly('2023-01-01');
     const date = dateOnly.toDate();
-    expect(date.getTime()).toBe(Date.UTC(2023, 0, 1));
+    expect(date.getTime()).toBe(new Date(2023, 0, 1).getTime());
   });
 
   it('should compare two DateOnly instances correctly', () => {

--- a/src/classes/date-only.ts
+++ b/src/classes/date-only.ts
@@ -4,17 +4,10 @@ type DateOnlyPropertyKeys =
   | 'toString'
   | 'toISOString'
   | 'toJSON'
-  | 'getUTCDate'
-  | 'getUTCMonth'
-  | 'getUTCFullYear'
-  | 'getUTCDay'
   | 'getDate'
   | 'getMonth'
   | 'getFullYear'
   | 'getDay'
-  | 'setUTCDate'
-  | 'setUTCMonth'
-  | 'setUTCFullYear'
   | 'setDate'
   | 'setMonth'
   | 'setFullYear';
@@ -61,11 +54,17 @@ export class DateOnly implements Pick<Date, DateOnlyPropertyKeys> {
     if (arguments.length === 0) this.date = new Date();
     else if (arguments.length === 3)
       this.date = new Date(
-        Date.UTC(valueOrYear as number, monthIndex as number, date as number),
+        valueOrYear as number,
+        monthIndex as number,
+        date as number,
+        0,
+        0,
+        0,
+        0,
       );
     else this.date = new Date(valueOrYear);
 
-    this.date.setUTCHours(0, 0, 0, 0); // Set time to midnight UTC
+    this.date.setHours(0, 0, 0, 0); // Set time to midnight
   }
 
   toString(): string {
@@ -73,7 +72,10 @@ export class DateOnly implements Pick<Date, DateOnlyPropertyKeys> {
   }
 
   toISOString(): string {
-    return this.date.toISOString().split('T')[0]; // Return only the date part
+    const year = this.getFullYear().toString().padStart(4, '0');
+    const month = (this.getMonth() + 1).toString().padStart(2, '0');
+    const date = this.getDate().toString().padStart(2, '0');
+    return `${year}-${month}-${date}`;
   }
 
   toJSON(): string {
@@ -93,23 +95,8 @@ export class DateOnly implements Pick<Date, DateOnlyPropertyKeys> {
    * @returns The date as a number of milliseconds.
    */
   getTime(): number {
-    return this.date.getTime();
-  }
-
-  getUTCDate(): number {
-    return this.date.getUTCDate();
-  }
-
-  getUTCMonth(): number {
-    return this.date.getUTCMonth();
-  }
-
-  getUTCFullYear(): number {
-    return this.date.getUTCFullYear();
-  }
-
-  getUTCDay(): number {
-    return this.date.getUTCDay();
+    const timezoneOffset = this.date.getTimezoneOffset() * 60 * 1000;
+    return this.date.getTime() - timezoneOffset;
   }
 
   getDate(): number {
@@ -126,21 +113,6 @@ export class DateOnly implements Pick<Date, DateOnlyPropertyKeys> {
 
   getDay(): number {
     return this.date.getDay();
-  }
-
-  setUTCDate(date: number): number {
-    this.date.setUTCDate(date);
-    return this.getTime();
-  }
-
-  setUTCMonth(month: number): number {
-    this.date.setUTCMonth(month);
-    return this.getTime();
-  }
-
-  setUTCFullYear(year: number): number {
-    this.date.setUTCFullYear(year);
-    return this.getTime();
   }
 
   setDate(date: number): number {

--- a/src/consts/date-resolvers/day-of-week-resolver.ts
+++ b/src/consts/date-resolvers/day-of-week-resolver.ts
@@ -55,10 +55,10 @@ export const DAY_OF_WEEK_RESOLVER = createDateResolver(
     const nextOccurrences = basicFlagValues.map((dayFlagValue) => {
       const dayIndex = dayFlagToDayIndex(dayFlagValue);
       const today = new Date();
-      const todayDayOfWeek = today.getUTCDay();
+      const todayDayOfWeek = today.getDay();
       const daysUntilNextOccurrence = (dayIndex + 7 - todayDayOfWeek) % 7 || 7; // If it's today, go to next week
       const nextOccurrence = new DateOnly(today);
-      nextOccurrence.setUTCDate(today.getUTCDate() + daysUntilNextOccurrence);
+      nextOccurrence.setDate(today.getDate() + daysUntilNextOccurrence);
       logger.debug('Calculating for day index', {
         dayIndex,
         dayFlagValue,


### PR DESCRIPTION
## Summary

As explained in #71, presets are applied to a past date. From a bit of research it seems like the issue is caused by time zones, and more specifically, time zones behind UTC.

In the `DateOnly` struct we strip the time by resetting the UTC timezone, which will have no effect on the day itself if the local time zone is positive, but will cause the day to be changed if it is negative, and will cause the day to be yesterday's.

## Changes

Instead of using UTC methods to manipulate the date (and which occur only in the struct's constructor), use the local alternatives for it. It has zero impact on other features, but will allow calculating the actual date correctly.

## Preview

A preview release has been deployed and can be tested via this link: https://deployable-assets.editorx.dev/wme-closures-plus@ea6733e.user.js.

## User Feedback

Confirmed as fixed by the reporter.

Closes #71