### PR TITLE
feat: move DurationPicker's helper message to tooltip

### DIFF
--- a/src/components/DurationPicker.tsx
+++ b/src/components/DurationPicker.tsx
@@ -31,8 +31,19 @@ export function DurationPicker(props: DurationPickerProps) {
       onBlur={onBlur}
       onKeyDown={onKeyDown}
       errorMessage={error ? t('duration_picker.errors')[error] : null}
-      helperMessage={t('duration_picker.helper')}
       autocomplete="off"
-    />
+    >
+      <div slot="trailing-icon">
+        <wz-basic-tooltip>
+          <wz-tooltip-source>
+            <i className="w-icon w-icon-info"></i>
+          </wz-tooltip-source>
+          <wz-tooltip-target></wz-tooltip-target>
+          <wz-tooltip-content>
+            {t('duration_picker.helper')}
+          </wz-tooltip-content>
+        </wz-basic-tooltip>
+      </div>
+    </wz-text-input>
   );
 }

--- a/src/components/DurationPicker.tsx
+++ b/src/components/DurationPicker.tsx
@@ -33,7 +33,7 @@ export function DurationPicker(props: DurationPickerProps) {
       errorMessage={error ? t('duration_picker.errors')[error] : null}
       autocomplete="off"
     >
-      <div slot="trailing-icon">
+      <div slot="trailing-icon" style={{ margin: 'auto', fontSize: '24px' }}>
         <wz-basic-tooltip>
           <wz-tooltip-source>
             <i className="w-icon w-icon-info"></i>

--- a/src/localization/static/userscript.json
+++ b/src/localization/static/userscript.json
@@ -111,7 +111,7 @@
     "errors": {
       "INVALID_PATTERN": "* Invalid format"
     },
-    "helper": "Use number+unit (m for minutes, h for hours, d for days, w for weeks). Combine, e.g., `1h 30m`."
+    "helper": "Enter duration using numbers followed by units (w: weeks, d: days, h: hours, m: minutes). Example: '1h 30m'."
   },
   "sidebar_tab": {
     "closure_presets": {


### PR DESCRIPTION
## Summary

Following issue #75 about moving the helper message of the picker to a tooltip for better UI harmony, this task has been delegated to the @google-labs-jules agent.

In the scope of this task and pull request, it removed the helper message from the input and instead added a trailing info icon that shows a tooltip on hover. It reuses Waze's native implementation of tooltips to keep consistent with the overall UI.

Additionally, it updates the text a bit for better clarity.

## Linked Issues

Closes: #75.