### PR TITLE
feat: postponing end time of a closure preset in fixed end time mode

### DIFF
--- a/src/components/closure-presets/preset-edit-dialog/PresetEditDialog.tsx
+++ b/src/components/closure-presets/preset-edit-dialog/PresetEditDialog.tsx
@@ -83,6 +83,7 @@ export function PresetEditingDialog(props: PresetEditingDialogProps) {
                 hours: closureDetailsData.endTime!.value.getHours(),
                 minutes: closureDetailsData.endTime!.value.getMinutes(),
               },
+              postponeBy: closureDetailsData.endTime!.postponeBy,
             };
             break;
           case 'DURATIONAL': {
@@ -171,6 +172,7 @@ export function PresetEditingDialog(props: PresetEditingDialogProps) {
                   0,
                   0,
                 ),
+                postponeBy: props.preset.closureDetails.end.postponeBy,
               }
             : props.preset.closureDetails.end.type === 'DURATIONAL' ?
               {

--- a/src/components/closure-presets/preset-edit-dialog/interfaces/preset-edit-dialog-data.ts
+++ b/src/components/closure-presets/preset-edit-dialog/interfaces/preset-edit-dialog-data.ts
@@ -24,6 +24,7 @@ export type PresetEditDialogData = {
       | {
           type: 'FIXED';
           value: TimeOnly;
+          postponeBy: number;
         }
       | {
           type: 'DURATIONAL';

--- a/src/components/stepper/utils/create-use-step-state.ts
+++ b/src/components/stepper/utils/create-use-step-state.ts
@@ -31,11 +31,13 @@ export function createUseStepState<D extends object>(
         updateStepData(currentStepConfig.id, {
           [key]:
             typeof newValue === 'function' ?
-              (newValue as () => D[K])()
+              (newValue as (prevValue: D[K]) => D[K])(
+                getStepData(currentStepConfig.id)[key],
+              )
             : newValue,
         });
       },
-      [currentStepConfig.id, key, updateStepData],
+      [currentStepConfig.id, getStepData, key, updateStepData],
     );
 
     (() => {

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -5,8 +5,18 @@ const db = new Dexie(__SCRIPT_ID__) as Dexie & {
   closurePresets: EntityTable<ClosurePreset, 'id'>;
 };
 
-db.version(1).stores({
-  closurePresets: '++id, name, createdAt, updatedAt',
-});
+db.version(2)
+  .stores({
+    closurePresets: '++id, name, createdAt, updatedAt',
+  })
+  .upgrade((transaction) => {
+    return transaction
+      .table('closurePresets')
+      .toCollection()
+      .modify((closurePreset: ClosurePreset) => {
+        if (closurePreset.closureDetails.end.type !== 'FIXED') return;
+        closurePreset.closureDetails.end.postponeBy = 0;
+      });
+  });
 
 export { db };

--- a/src/interfaces/closure-preset.ts
+++ b/src/interfaces/closure-preset.ts
@@ -6,6 +6,7 @@ interface ClosureFixedEnd {
     hours: number;
     minutes: number;
   };
+  postponeBy: number;
 }
 interface ClosureDurationalEnd {
   type: 'DURATIONAL';

--- a/src/localization/static/userscript.json
+++ b/src/localization/static/userscript.json
@@ -96,7 +96,8 @@
               "modes": {
                 "FIXED": "Specific time",
                 "DURATIONAL": "Durational"
-              }
+              },
+              "postpone_by": "Postpone by"
             }
           },
           "SUMMARY": {

--- a/src/utils/apply-closure-preset.ts
+++ b/src/utils/apply-closure-preset.ts
@@ -102,6 +102,14 @@ function getEndDateForPreset(
         // we need to apply the end time to the next day
         endDate.setDate(endDate.getDate() + 1);
       }
+      if (endDetails.postponeBy) {
+        logger.debug(
+          `Postponing the end time by ${endDetails.postponeBy} minutes`,
+        );
+        const time = endDate.getTime();
+        const postponeByMs = endDetails.postponeBy * 60 * 1000;
+        endDate.setTime(time + postponeByMs);
+      }
       return endDate;
     }
     default:


### PR DESCRIPTION
## Summary

This pull request provides a new feature: the Ability to postpone the end time by a given duration when using a closure preset with a fixed end time. This allows for more robust and flexible presets that might span multiple days.

## Implementation Details

To implement this feature, I had to make changes to the IndexedDB schema, to the preset application algorithm, and, of course, changes to the UI of the preset edit dialog.

### IndexedDB changes

Changes to the IndexedDB include schema changes: Addition of a new column for holding the value of the postpone duration. The selected data type for this value is a number, representing the number of minutes to postpone by. It is derived directly from the `DurationPicker` used to define the value.

To ensure users won't lose their presets and to prevent unexpected issues, a migration function has been put in place, incrementing the IndexedDB version and specifying the value of `0` as the default value for postponing presets.

### Preset Application Algorithm

The preset application algorithm has also been modified to accommodate the new setting. The change here is simple: After all calculations to the end date are done, add the provided amount of minutes from the preset config to the end time. It is done by converting the number of minutes to a corresponding amount of milliseconds acceptable by the `setTime` method of a `Date` instance. To change is also reflected as a separate step in the logs.

### Preset Edit Dialog

The preset edit dialog has also received an update as part of this change, adding a new checkbox for enabling postponing, followed by a duration picker controlling the value.

### Other minor changes

The only other change done in this pull request fixes a bug with the stepper data handling, preventing from utilization of the full power of setter functions that accept the previous value. This pull request fixes it and passes the previous value correctly to the setter function.

## Known Issues and Areas to Improve

When refactoring and implementing this new feature, I discovered a few areas to improve our codebase, which are well beyond the scope of this task. @coderabbitai feel free to create separate tickets for each of these or link existing issues.

1. Research and refactor the React layout structure of every start mode in the edit dialog.
2. Research and refactor the React layout structure of every end mode in the edit dialog.
3. Refactor the `TimePicker` component to work with `DateOnly` values (#88).

## Call to Action

User feedback is requested! Be the first to try out the changes in this pull request by installing this version: https://deployable-assets.editorx.dev/wme-closures-plus@ce821cd.user.js.

## Linked Issues

Closes: #72.